### PR TITLE
chore: remove test PyPI repository URL from publish step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,3 @@ jobs:
           subject-path: "dist/*"
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # Remember to tell (test-)pypi about this repo before publishing
-          # Remove this line to publish to PyPI
-          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This fixes the release process

Since the alignment with the Scientific Pyhon Packaging standards the GitHub Action has been changed and the trusted publisher was not working anymore and had to be updated on the pipit account.

Also by default the publishing url was pointing the test instance of PyPI instead of the production one. This was fixed is this PR
