### PR TITLE
feat: refactor logging system with Loguru integration and centralized…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,19 @@ and this project adheres to
 
 - **Breaking:** logging is now silent by default. Call
   `magpylib_material_response.configure_logging()` (or
-  `loguru.logger.enable("magpylib_material_response")`) to opt in to log
-  output ([#30](https://github.com/magpylib/magpylib-material-response/pull/30)).
+  `loguru.logger.enable("magpylib_material_response")`) to opt in to log output
+  ([#30](https://github.com/magpylib/magpylib-material-response/pull/30)).
 - Refactored logging to follow the
   [loguru library recipe](https://loguru.readthedocs.io/en/stable/resources/recipes.html#configuring-loguru-to-be-used-by-a-library-or-an-application):
   the package no longer calls `logger.remove()` and never overrides sinks
   configured by the host application.
-- Replaced f-string log calls with structured logging (`logger.info("msg {x}", x=...)`).
+- Replaced f-string log calls with structured logging
+  (`logger.info("msg {x}", x=...)`).
 - Added `MAGPYLIB_LOG_LEVEL`, `MAGPYLIB_LOG_COLORS`, `MAGPYLIB_LOG_TIME`,
   `MAGPYLIB_LOG_MIN_TIME` environment variables.
-- Added a `min_log_time` argument to `configure_logging()` that sets the
-  default duration threshold used by `timelog` (and by the demag functions
-  when their own `min_log_time` argument is left at its default).
+- Added a `min_log_time` argument to `configure_logging()` that sets the default
+  duration threshold used by `timelog` (and by the demag functions when their
+  own `min_log_time` argument is left at its default).
 - Added `docs/logging.md`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** logging is now silent by default. Call
+  `magpylib_material_response.configure_logging()` (or
+  `loguru.logger.enable("magpylib_material_response")`) to opt in to log output
+  ([#30](https://github.com/magpylib/magpylib-material-response/pull/30)).
+- Refactored logging to follow the
+  [loguru library recipe](https://loguru.readthedocs.io/en/stable/resources/recipes.html#configuring-loguru-to-be-used-by-a-library-or-an-application):
+  the package no longer calls `logger.remove()` and never overrides sinks
+  configured by the host application.
+- Replaced f-string log calls with structured logging
+  (`logger.info("msg {x}", x=...)`).
+- Added `MAGPYLIB_LOG_LEVEL`, `MAGPYLIB_LOG_COLORS`, `MAGPYLIB_LOG_TIME`,
+  `MAGPYLIB_LOG_MIN_TIME` environment variables.
+- Added a `min_log_time` argument to `configure_logging()` that sets the default
+  duration threshold used by `timelog` (and by the demag functions when their
+  own `min_log_time` argument is left at its default).
+- Added `docs/logging.md`.
+
+### Fixed
+
+- `timelog` no longer raises `TypeError` on the failure path when the wrapped
+  block raises an exception.
+
 ## [0.3.1] - 2025-10-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** logging is now silent by default. Call
+  `magpylib_material_response.configure_logging()` (or
+  `loguru.logger.enable("magpylib_material_response")`) to opt in to log
+  output ([#30](https://github.com/magpylib/magpylib-material-response/pull/30)).
+- Refactored logging to follow the
+  [loguru library recipe](https://loguru.readthedocs.io/en/stable/resources/recipes.html#configuring-loguru-to-be-used-by-a-library-or-an-application):
+  the package no longer calls `logger.remove()` and never overrides sinks
+  configured by the host application.
+- Replaced f-string log calls with structured logging (`logger.info("msg {x}", x=...)`).
+- Added `MAGPYLIB_LOG_LEVEL`, `MAGPYLIB_LOG_COLORS`, `MAGPYLIB_LOG_TIME`,
+  `MAGPYLIB_LOG_MIN_TIME` environment variables.
+- Added a `min_log_time` argument to `configure_logging()` that sets the
+  default duration threshold used by `timelog` (and by the demag functions
+  when their own `min_log_time` argument is left at its default).
+- Added `docs/logging.md`.
+
+### Fixed
+
+- `timelog` no longer raises `TypeError` on the failure path when the wrapped
+  block raises an exception.
+
 ## [0.3.1] - 2025-10-30
 
 ### Fixed

--- a/docs/examples/cuboids_demagnetization.md
+++ b/docs/examples/cuboids_demagnetization.md
@@ -36,9 +36,16 @@ import magpylib as magpy
 import numpy as np
 import pandas as pd
 import plotly.express as px
-from magpylib_material_response import get_dataset
+from magpylib_material_response import get_dataset, configure_logging
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_all
+from magpylib_material_response.logging_config import get_logger
+
+# Configure logging to see progress messages
+configure_logging()
+
+# Initialize logger for contextualized logging
+logger = get_logger("magpylib_material_response.examples.cuboids_demagnetization")
 
 if magpy.__version__.split(".")[0] != "5":
     raise RuntimeError(
@@ -89,15 +96,19 @@ coll_meshed.show()
 # apply demagnetization with varying number of cells
 colls = [coll]
 for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
-    with logger.contextualize(target_elems=target_elems):
-        coll_meshed = mesh_all(
-            coll, target_elems=target_elems, per_child_elems=True, min_elems=1
-        )
-        coll_demag = apply_demag(
-            coll_meshed,
-            style={"label": f"Coll_demag ({len(coll_meshed.sources_all):3d} cells)"},
-        )
-        colls.append(coll_demag)
+    logger.info("🔄 Processing demagnetization with {target_elems} target elements", target_elems=target_elems)
+    
+    coll_meshed = mesh_all(
+        coll, target_elems=target_elems, per_child_elems=True, min_elems=1
+    )
+    
+    coll_demag = apply_demag(
+        coll_meshed,
+        style={"label": f"Coll_demag ({len(coll_meshed.sources_all):3d} cells)"},
+    )
+    colls.append(coll_demag)
+    
+    logger.info("✅ Completed demagnetization: {actual_cells} cells created", actual_cells=len(coll_meshed.sources_all))
 ```
 
 ## Compare with FEM analysis

--- a/docs/examples/cuboids_demagnetization.md
+++ b/docs/examples/cuboids_demagnetization.md
@@ -97,17 +97,17 @@ coll_meshed.show()
 colls = [coll]
 for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
     logger.info("🔄 Processing demagnetization with {target_elems} target elements", target_elems=target_elems)
-    
+
     coll_meshed = mesh_all(
         coll, target_elems=target_elems, per_child_elems=True, min_elems=1
     )
-    
+
     coll_demag = apply_demag(
         coll_meshed,
         style={"label": f"Coll_demag ({len(coll_meshed.sources_all):3d} cells)"},
     )
     colls.append(coll_demag)
-    
+
     logger.info("✅ Completed demagnetization: {actual_cells} cells created", actual_cells=len(coll_meshed.sources_all))
 ```
 

--- a/docs/examples/cuboids_demagnetization.md
+++ b/docs/examples/cuboids_demagnetization.md
@@ -36,7 +36,6 @@ import magpylib as magpy
 import numpy as np
 import pandas as pd
 import plotly.express as px
-from loguru import logger
 from magpylib_material_response import get_dataset
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_all

--- a/docs/examples/cuboids_demagnetization.md
+++ b/docs/examples/cuboids_demagnetization.md
@@ -39,13 +39,9 @@ import plotly.express as px
 from magpylib_material_response import get_dataset, configure_logging
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_all
-from magpylib_material_response.logging_config import get_logger
 
-# Configure logging to see progress messages
+# Enable logging output from the package (silent by default).
 configure_logging()
-
-# Initialize logger for contextualized logging
-logger = get_logger("magpylib_material_response.examples.cuboids_demagnetization")
 
 if magpy.__version__.split(".")[0] != "5":
     raise RuntimeError(
@@ -96,7 +92,7 @@ coll_meshed.show()
 # apply demagnetization with varying number of cells
 colls = [coll]
 for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
-    logger.info("🔄 Processing demagnetization with {target_elems} target elements", target_elems=target_elems)
+    print(f"Processing demagnetization with {target_elems} target elements")
 
     coll_meshed = mesh_all(
         coll, target_elems=target_elems, per_child_elems=True, min_elems=1
@@ -108,7 +104,7 @@ for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
     )
     colls.append(coll_demag)
 
-    logger.info("✅ Completed demagnetization: {actual_cells} cells created", actual_cells=len(coll_meshed.sources_all))
+    logger.info("Completed demagnetization: {actual_cells} cells created", actual_cells=len(coll_meshed.sources_all))
 ```
 
 ## Compare with FEM analysis

--- a/docs/examples/cuboids_demagnetization.md
+++ b/docs/examples/cuboids_demagnetization.md
@@ -36,12 +36,13 @@ import magpylib as magpy
 import numpy as np
 import pandas as pd
 import plotly.express as px
-from magpylib_material_response import get_dataset, configure_logging
+from magpylib_material_response import get_dataset
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_all
 
-# Enable logging output from the package (silent by default).
-configure_logging()
+# Uncomment to enable logging output from the package (silent by default).
+# from magpylib_material_response import configure_logging
+# configure_logging(min_log_time=5)  # log steps taking longer than 5 s
 
 if magpy.__version__.split(".")[0] != "5":
     raise RuntimeError(

--- a/docs/examples/cuboids_demagnetization.md
+++ b/docs/examples/cuboids_demagnetization.md
@@ -104,7 +104,7 @@ for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
     )
     colls.append(coll_demag)
 
-    logger.info("Completed demagnetization: {actual_cells} cells created", actual_cells=len(coll_meshed.sources_all))
+    print(f"Completed demagnetization: {len(coll_meshed.sources_all)} cells created")
 ```
 
 ## Compare with FEM analysis

--- a/docs/examples/soft_magnets.md
+++ b/docs/examples/soft_magnets.md
@@ -35,8 +35,16 @@ import magpylib as magpy
 import numpy as np
 import pandas as pd
 import plotly.express as px
+from magpylib_material_response import configure_logging
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_all
+from magpylib_material_response.logging_config import get_logger
+
+# Configure logging to see progress messages
+configure_logging()
+
+# Initialize logger for contextualized logging
+logger = get_logger("magpylib_material_response.examples.soft_magnets")
 
 magpy.defaults.display.backend = "plotly"
 
@@ -83,15 +91,19 @@ magpy.show(*coll_meshed)
 # apply demagnetization with varying number of cells
 colls = [coll]
 for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
-    with logger.contextualize(target_elems=target_elems):
-        coll_meshed = mesh_all(
-            coll, target_elems=target_elems, per_child_elems=True, min_elems=1
-        )
-        coll_demag = apply_demag(
-            coll_meshed,
-            style={"label": f"Coll_demag ({len(coll_meshed.sources_all):3d} cells)"},
-        )
-        colls.append(coll_demag)
+    logger.info("🔄 Processing demagnetization with {target_elems} target elements", target_elems=target_elems)
+    
+    coll_meshed = mesh_all(
+        coll, target_elems=target_elems, per_child_elems=True, min_elems=1
+    )
+    
+    coll_demag = apply_demag(
+        coll_meshed,
+        style={"label": f"Coll_demag ({len(coll_meshed.sources_all):3d} cells)"},
+    )
+    colls.append(coll_demag)
+    
+    logger.info("✅ Completed demagnetization: {actual_cells} cells created", actual_cells=len(coll_meshed.sources_all))
 ```
 
 +++ {"user_expressions": []}

--- a/docs/examples/soft_magnets.md
+++ b/docs/examples/soft_magnets.md
@@ -35,7 +35,6 @@ import magpylib as magpy
 import numpy as np
 import pandas as pd
 import plotly.express as px
-from loguru import logger
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_all
 

--- a/docs/examples/soft_magnets.md
+++ b/docs/examples/soft_magnets.md
@@ -92,17 +92,17 @@ magpy.show(*coll_meshed)
 colls = [coll]
 for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
     logger.info("🔄 Processing demagnetization with {target_elems} target elements", target_elems=target_elems)
-    
+
     coll_meshed = mesh_all(
         coll, target_elems=target_elems, per_child_elems=True, min_elems=1
     )
-    
+
     coll_demag = apply_demag(
         coll_meshed,
         style={"label": f"Coll_demag ({len(coll_meshed.sources_all):3d} cells)"},
     )
     colls.append(coll_demag)
-    
+
     logger.info("✅ Completed demagnetization: {actual_cells} cells created", actual_cells=len(coll_meshed.sources_all))
 ```
 

--- a/docs/examples/soft_magnets.md
+++ b/docs/examples/soft_magnets.md
@@ -35,12 +35,12 @@ import magpylib as magpy
 import numpy as np
 import pandas as pd
 import plotly.express as px
-from magpylib_material_response import configure_logging
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_all
 
-# Enable logging output from the package (silent by default).
-configure_logging()
+# Uncomment to enable logging output from the package (silent by default).
+# from magpylib_material_response import configure_logging
+# configure_logging(min_log_time=5)  # log steps taking longer than 5 s
 
 magpy.defaults.display.backend = "plotly"
 

--- a/docs/examples/soft_magnets.md
+++ b/docs/examples/soft_magnets.md
@@ -38,13 +38,9 @@ import plotly.express as px
 from magpylib_material_response import configure_logging
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_all
-from magpylib_material_response.logging_config import get_logger
 
-# Configure logging to see progress messages
+# Enable logging output from the package (silent by default).
 configure_logging()
-
-# Initialize logger for contextualized logging
-logger = get_logger("magpylib_material_response.examples.soft_magnets")
 
 magpy.defaults.display.backend = "plotly"
 
@@ -91,7 +87,7 @@ magpy.show(*coll_meshed)
 # apply demagnetization with varying number of cells
 colls = [coll]
 for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
-    logger.info("🔄 Processing demagnetization with {target_elems} target elements", target_elems=target_elems)
+    print(f"Processing demagnetization with {target_elems} target elements")
 
     coll_meshed = mesh_all(
         coll, target_elems=target_elems, per_child_elems=True, min_elems=1
@@ -103,7 +99,7 @@ for target_elems in [1, 2, 8, 16, 32, 64, 128, 256]:
     )
     colls.append(coll_demag)
 
-    logger.info("✅ Completed demagnetization: {actual_cells} cells created", actual_cells=len(coll_meshed.sources_all))
+    print(f"Completed demagnetization: {len(coll_meshed.sources_all)} cells created")
 ```
 
 +++ {"user_expressions": []}

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 :glob: true
 :maxdepth: 2
 
+logging
 examples/index
 ```
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,117 @@
+# Logging Configuration
+
+The magpylib-material-response package uses structured logging with [Loguru](https://loguru.readthedocs.io/) to provide informative messages about computation progress and debugging information.
+
+## Default Behavior
+
+By default, the library **does not output any log messages**. This follows best practices for Python libraries to avoid cluttering user output unless explicitly requested.
+
+## Enabling Logging
+
+To see log messages from the library, you need to configure logging:
+
+```python
+from magpylib_material_response import configure_logging
+from magpylib_material_response.demag import apply_demag
+
+# Enable logging with default settings (INFO level, colored output to stderr)
+configure_logging()
+
+# Now use the library - you'll see progress messages
+# ... your code here
+```
+
+## Configuration Options
+
+### Log Level
+```python
+from magpylib_material_response import configure_logging
+
+# Set to DEBUG for detailed internal operations
+configure_logging(level="DEBUG")
+
+# Set to WARNING to only see important warnings and errors
+configure_logging(level="WARNING")
+
+# Available levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+```
+
+### Output Destination
+```python
+import sys
+from magpylib_material_response import configure_logging
+
+# Output to stdout instead of stderr
+configure_logging(sink=sys.stdout)
+
+# Output to a file
+configure_logging(sink="/path/to/logfile.log")
+```
+
+### Disable Colors and Time
+```python
+from magpylib_material_response import configure_logging
+
+# Disable colored output (useful for log files)
+configure_logging(enable_colors=False)
+
+# Disable timestamps
+configure_logging(show_time=False)
+```
+
+## Environment Variables
+
+You can also configure logging using environment variables:
+
+```bash
+# Set log level
+export MAGPYLIB_LOG_LEVEL=DEBUG
+
+# Disable colors
+export MAGPYLIB_LOG_COLORS=false
+
+# Disable timestamps
+export MAGPYLIB_LOG_TIME=false
+```
+
+## Disabling Logging
+
+To completely disable logging output:
+
+```python
+from magpylib_material_response import disable_logging
+
+disable_logging()
+```
+
+## Example Usage
+
+```python
+import magpylib as magpy
+from magpylib_material_response import configure_logging
+from magpylib_material_response.demag import apply_demag
+from magpylib_material_response.meshing import mesh_Cuboid
+
+# Enable logging to see progress
+configure_logging(level="INFO")
+
+# Create a magnet
+magnet = magpy.magnet.Cuboid(
+    dimension=(0.01, 0.01, 0.02),
+    polarization=(0, 0, 1)
+)
+magnet.susceptibility = 0.1
+
+# Mesh the magnet - you'll see meshing progress
+meshed = mesh_Cuboid(magnet, target_elems=1000, verbose=True)
+
+# Apply demagnetization - you'll see computation progress
+apply_demag(meshed, inplace=True)
+```
+
+This will output structured log messages showing the progress of operations, timing information, and any warnings or errors.
+
+## See Also
+
+- {doc}`examples/index` - Working examples that demonstrate logging output
+- [Loguru Documentation](https://loguru.readthedocs.io/) - Complete reference for the underlying logging library

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,10 +1,14 @@
 # Logging Configuration
 
-The magpylib-material-response package uses structured logging with [Loguru](https://loguru.readthedocs.io/) to provide informative messages about computation progress and debugging information.
+The magpylib-material-response package uses structured logging with
+[Loguru](https://loguru.readthedocs.io/) to provide informative messages about
+computation progress and debugging information.
 
 ## Default Behavior
 
-By default, the library **does not output any log messages**. This follows best practices for Python libraries to avoid cluttering user output unless explicitly requested.
+By default, the library **does not output any log messages**. This follows best
+practices for Python libraries to avoid cluttering user output unless explicitly
+requested.
 
 ## Enabling Logging
 
@@ -24,6 +28,7 @@ configure_logging()
 ## Configuration Options
 
 ### Log Level
+
 ```python
 from magpylib_material_response import configure_logging
 
@@ -37,6 +42,7 @@ configure_logging(level="WARNING")
 ```
 
 ### Output Destination
+
 ```python
 import sys
 from magpylib_material_response import configure_logging
@@ -49,6 +55,7 @@ configure_logging(sink="/path/to/logfile.log")
 ```
 
 ### Disable Colors and Time
+
 ```python
 from magpylib_material_response import configure_logging
 
@@ -96,10 +103,7 @@ from magpylib_material_response.meshing import mesh_Cuboid
 configure_logging(level="INFO")
 
 # Create a magnet
-magnet = magpy.magnet.Cuboid(
-    dimension=(0.01, 0.01, 0.02),
-    polarization=(0, 0, 1)
-)
+magnet = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.02), polarization=(0, 0, 1))
 magnet.susceptibility = 0.1
 
 # Mesh the magnet - you'll see meshing progress
@@ -109,9 +113,11 @@ meshed = mesh_Cuboid(magnet, target_elems=1000, verbose=True)
 apply_demag(meshed, inplace=True)
 ```
 
-This will output structured log messages showing the progress of operations, timing information, and any warnings or errors.
+This will output structured log messages showing the progress of operations,
+timing information, and any warnings or errors.
 
 ## See Also
 
 - {doc}`examples/index` - Working examples that demonstrate logging output
-- [Loguru Documentation](https://loguru.readthedocs.io/) - Complete reference for the underlying logging library
+- [Loguru Documentation](https://loguru.readthedocs.io/) - Complete reference
+  for the underlying logging library

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,18 +1,20 @@
 # Logging Configuration
 
-The magpylib-material-response package uses structured logging with
-[Loguru](https://loguru.readthedocs.io/) to provide informative messages about
+The magpylib-material-response package uses
+[Loguru](https://loguru.readthedocs.io/) to emit informative messages about
 computation progress and debugging information.
 
 ## Default Behavior
 
-By default, the library **does not output any log messages**. This follows best
-practices for Python libraries to avoid cluttering user output unless explicitly
-requested.
+Following the
+[recommended pattern for libraries](https://loguru.readthedocs.io/en/stable/resources/recipes.html#configuring-loguru-to-be-used-by-a-library-or-an-application),
+the package is **disabled at import time** and produces no output until the
+user opts in. Importing the package never adds, removes or replaces any
+loguru sinks already configured by the host application.
 
 ## Enabling Logging
 
-To see log messages from the library, you need to configure logging:
+To see log messages from the library, call `configure_logging()`:
 
 ```python
 from magpylib_material_response import configure_logging
@@ -20,9 +22,23 @@ from magpylib_material_response.demag import apply_demag
 
 # Enable logging with default settings (INFO level, colored output to stderr)
 configure_logging()
+```
 
-# Now use the library - you'll see progress messages
-# ... your code here
+`configure_logging()` adds a sink that only receives records emitted from
+within the `magpylib_material_response` package. It is safe to call multiple
+times; each call replaces only the sink it added previously, leaving any
+other loguru sinks untouched.
+
+```{note}
+By default, loguru ships with a pre-installed `sys.stderr` sink (handler id
+`0`). Because `configure_logging()` does not touch sinks it did not add, you
+may see each package record appear **twice**: once via loguru's default
+handler and once via the sink added by `configure_logging`. To avoid this,
+remove the default handler before configuring:
+
+    from loguru import logger
+    logger.remove(0)
+    configure_logging()
 ```
 
 ## Configuration Options
@@ -30,65 +46,77 @@ configure_logging()
 ### Log Level
 
 ```python
-from magpylib_material_response import configure_logging
-
-# Set to DEBUG for detailed internal operations
-configure_logging(level="DEBUG")
-
-# Set to WARNING to only see important warnings and errors
-configure_logging(level="WARNING")
-
-# Available levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+configure_logging(level="DEBUG")    # detailed internal operations
+configure_logging(level="WARNING")  # only warnings and errors
+# Available: DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 ### Output Destination
 
 ```python
 import sys
-from magpylib_material_response import configure_logging
 
-# Output to stdout instead of stderr
-configure_logging(sink=sys.stdout)
-
-# Output to a file
-configure_logging(sink="/path/to/logfile.log")
+configure_logging(sink=sys.stdout)        # stdout instead of stderr
+configure_logging(sink="/path/to/file.log")  # log file
 ```
 
 ### Disable Colors and Time
 
 ```python
-from magpylib_material_response import configure_logging
-
-# Disable colored output (useful for log files)
-configure_logging(enable_colors=False)
-
-# Disable timestamps
+configure_logging(enable_colors=False)  # useful for log files
 configure_logging(show_time=False)
 ```
 
+### Step Timing Threshold
+
+The library wraps long-running steps in a `timelog` context that emits a
+"Completed: ..." record when the step exceeds a duration threshold. The
+default is `1.0` second.
+
+```python
+# Log every step, regardless of duration:
+configure_logging(min_log_time=0)
+
+# Only log very long steps:
+configure_logging(min_log_time=10)
+```
+
+This setting is also picked up by `apply_demag`, `demag_tensor`,
+`filter_distance`, and `match_pairs` whenever their own `min_log_time`
+argument is left at its default (`None`). Passing an explicit value to those
+functions still overrides the global setting for that call.
+
 ## Environment Variables
 
-You can also configure logging using environment variables:
-
 ```bash
-# Set log level
 export MAGPYLIB_LOG_LEVEL=DEBUG
-
-# Disable colors
 export MAGPYLIB_LOG_COLORS=false
-
-# Disable timestamps
 export MAGPYLIB_LOG_TIME=false
+export MAGPYLIB_LOG_MIN_TIME=0
 ```
 
 ## Disabling Logging
-
-To completely disable logging output:
 
 ```python
 from magpylib_material_response import disable_logging
 
 disable_logging()
+```
+
+This re-disables the package and removes only the sink previously added by
+`configure_logging`.
+
+## Custom Application-Side Configuration
+
+If your application already configures loguru, you do not need to call
+`configure_logging()` at all. Instead, simply enable the package and let your
+own sinks handle the records:
+
+```python
+from loguru import logger
+
+logger.enable("magpylib_material_response")
+# your existing logger.add(...) sinks now also receive package records
 ```
 
 ## Example Usage
@@ -99,22 +127,14 @@ from magpylib_material_response import configure_logging
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_Cuboid
 
-# Enable logging to see progress
 configure_logging(level="INFO")
 
-# Create a magnet
 magnet = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.02), polarization=(0, 0, 1))
 magnet.susceptibility = 0.1
 
-# Mesh the magnet - you'll see meshing progress
 meshed = mesh_Cuboid(magnet, target_elems=1000, verbose=True)
-
-# Apply demagnetization - you'll see computation progress
 apply_demag(meshed, inplace=True)
 ```
-
-This will output structured log messages showing the progress of operations,
-timing information, and any warnings or errors.
 
 ## See Also
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,18 +1,20 @@
 # Logging Configuration
 
-The magpylib-material-response package uses structured logging with
-[Loguru](https://loguru.readthedocs.io/) to provide informative messages about
+The magpylib-material-response package uses
+[Loguru](https://loguru.readthedocs.io/) to emit informative messages about
 computation progress and debugging information.
 
 ## Default Behavior
 
-By default, the library **does not output any log messages**. This follows best
-practices for Python libraries to avoid cluttering user output unless explicitly
-requested.
+Following the
+[recommended pattern for libraries](https://loguru.readthedocs.io/en/stable/resources/recipes.html#configuring-loguru-to-be-used-by-a-library-or-an-application),
+the package is **disabled at import time** and produces no output until the user
+opts in. Importing the package never adds, removes or replaces any loguru sinks
+already configured by the host application.
 
 ## Enabling Logging
 
-To see log messages from the library, you need to configure logging:
+To see log messages from the library, call `configure_logging()`:
 
 ```python
 from magpylib_material_response import configure_logging
@@ -20,9 +22,23 @@ from magpylib_material_response.demag import apply_demag
 
 # Enable logging with default settings (INFO level, colored output to stderr)
 configure_logging()
+```
 
-# Now use the library - you'll see progress messages
-# ... your code here
+`configure_logging()` adds a sink that only receives records emitted from within
+the `magpylib_material_response` package. It is safe to call multiple times;
+each call replaces only the sink it added previously, leaving any other loguru
+sinks untouched.
+
+```{note}
+By default, loguru ships with a pre-installed `sys.stderr` sink (handler id
+`0`). Because `configure_logging()` does not touch sinks it did not add, you
+may see each package record appear **twice**: once via loguru's default
+handler and once via the sink added by `configure_logging`. To avoid this,
+remove the default handler before configuring:
+
+    from loguru import logger
+    logger.remove(0)
+    configure_logging()
 ```
 
 ## Configuration Options
@@ -30,65 +46,77 @@ configure_logging()
 ### Log Level
 
 ```python
-from magpylib_material_response import configure_logging
-
-# Set to DEBUG for detailed internal operations
-configure_logging(level="DEBUG")
-
-# Set to WARNING to only see important warnings and errors
-configure_logging(level="WARNING")
-
-# Available levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+configure_logging(level="DEBUG")  # detailed internal operations
+configure_logging(level="WARNING")  # only warnings and errors
+# Available: DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 ### Output Destination
 
 ```python
 import sys
-from magpylib_material_response import configure_logging
 
-# Output to stdout instead of stderr
-configure_logging(sink=sys.stdout)
-
-# Output to a file
-configure_logging(sink="/path/to/logfile.log")
+configure_logging(sink=sys.stdout)  # stdout instead of stderr
+configure_logging(sink="/path/to/file.log")  # log file
 ```
 
 ### Disable Colors and Time
 
 ```python
-from magpylib_material_response import configure_logging
-
-# Disable colored output (useful for log files)
-configure_logging(enable_colors=False)
-
-# Disable timestamps
+configure_logging(enable_colors=False)  # useful for log files
 configure_logging(show_time=False)
 ```
 
+### Step Timing Threshold
+
+The library wraps long-running steps in a `timelog` context that emits a
+"Completed: ..." record when the step exceeds a duration threshold. The default
+is `1.0` second.
+
+```python
+# Log every step, regardless of duration:
+configure_logging(min_log_time=0)
+
+# Only log very long steps:
+configure_logging(min_log_time=10)
+```
+
+This setting is also picked up by `apply_demag`, `demag_tensor`,
+`filter_distance`, and `match_pairs` whenever their own `min_log_time` argument
+is left at its default (`None`). Passing an explicit value to those functions
+still overrides the global setting for that call.
+
 ## Environment Variables
 
-You can also configure logging using environment variables:
-
 ```bash
-# Set log level
 export MAGPYLIB_LOG_LEVEL=DEBUG
-
-# Disable colors
 export MAGPYLIB_LOG_COLORS=false
-
-# Disable timestamps
 export MAGPYLIB_LOG_TIME=false
+export MAGPYLIB_LOG_MIN_TIME=0
 ```
 
 ## Disabling Logging
-
-To completely disable logging output:
 
 ```python
 from magpylib_material_response import disable_logging
 
 disable_logging()
+```
+
+This re-disables the package and removes only the sink previously added by
+`configure_logging`.
+
+## Custom Application-Side Configuration
+
+If your application already configures loguru, you do not need to call
+`configure_logging()` at all. Instead, simply enable the package and let your
+own sinks handle the records:
+
+```python
+from loguru import logger
+
+logger.enable("magpylib_material_response")
+# your existing logger.add(...) sinks now also receive package records
 ```
 
 ## Example Usage
@@ -99,22 +127,14 @@ from magpylib_material_response import configure_logging
 from magpylib_material_response.demag import apply_demag
 from magpylib_material_response.meshing import mesh_Cuboid
 
-# Enable logging to see progress
 configure_logging(level="INFO")
 
-# Create a magnet
 magnet = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.02), polarization=(0, 0, 1))
 magnet.susceptibility = 0.1
 
-# Mesh the magnet - you'll see meshing progress
 meshed = mesh_Cuboid(magnet, target_elems=1000, verbose=True)
-
-# Apply demagnetization - you'll see computation progress
 apply_demag(meshed, inplace=True)
 ```
-
-This will output structured log messages showing the progress of operations,
-timing information, and any warnings or errors.
 
 ## See Also
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -8,9 +8,9 @@ computation progress and debugging information.
 
 Following the
 [recommended pattern for libraries](https://loguru.readthedocs.io/en/stable/resources/recipes.html#configuring-loguru-to-be-used-by-a-library-or-an-application),
-the package is **disabled at import time** and produces no output until the
-user opts in. Importing the package never adds, removes or replaces any
-loguru sinks already configured by the host application.
+the package is **disabled at import time** and produces no output until the user
+opts in. Importing the package never adds, removes or replaces any loguru sinks
+already configured by the host application.
 
 ## Enabling Logging
 
@@ -24,10 +24,10 @@ from magpylib_material_response.demag import apply_demag
 configure_logging()
 ```
 
-`configure_logging()` adds a sink that only receives records emitted from
-within the `magpylib_material_response` package. It is safe to call multiple
-times; each call replaces only the sink it added previously, leaving any
-other loguru sinks untouched.
+`configure_logging()` adds a sink that only receives records emitted from within
+the `magpylib_material_response` package. It is safe to call multiple times;
+each call replaces only the sink it added previously, leaving any other loguru
+sinks untouched.
 
 ```{note}
 By default, loguru ships with a pre-installed `sys.stderr` sink (handler id
@@ -46,7 +46,7 @@ remove the default handler before configuring:
 ### Log Level
 
 ```python
-configure_logging(level="DEBUG")    # detailed internal operations
+configure_logging(level="DEBUG")  # detailed internal operations
 configure_logging(level="WARNING")  # only warnings and errors
 # Available: DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
@@ -56,7 +56,7 @@ configure_logging(level="WARNING")  # only warnings and errors
 ```python
 import sys
 
-configure_logging(sink=sys.stdout)        # stdout instead of stderr
+configure_logging(sink=sys.stdout)  # stdout instead of stderr
 configure_logging(sink="/path/to/file.log")  # log file
 ```
 
@@ -70,8 +70,8 @@ configure_logging(show_time=False)
 ### Step Timing Threshold
 
 The library wraps long-running steps in a `timelog` context that emits a
-"Completed: ..." record when the step exceeds a duration threshold. The
-default is `1.0` second.
+"Completed: ..." record when the step exceeds a duration threshold. The default
+is `1.0` second.
 
 ```python
 # Log every step, regardless of duration:
@@ -82,9 +82,9 @@ configure_logging(min_log_time=10)
 ```
 
 This setting is also picked up by `apply_demag`, `demag_tensor`,
-`filter_distance`, and `match_pairs` whenever their own `min_log_time`
-argument is left at its default (`None`). Passing an explicit value to those
-functions still overrides the global setting for that call.
+`filter_distance`, and `match_pairs` whenever their own `min_log_time` argument
+is left at its default (`None`). Passing an explicit value to those functions
+still overrides the global setting for that call.
 
 ## Environment Variables
 

--- a/src/magpylib_material_response/__init__.py
+++ b/src/magpylib_material_response/__init__.py
@@ -7,7 +7,8 @@ magpylib-material-response: Python package extending the Magpylib library by pro
 from __future__ import annotations
 
 from magpylib_material_response._data import get_dataset
+from magpylib_material_response.logging_config import configure_logging, disable_logging
 
 from ._version import version as __version__
 
-__all__ = ["__version__", "get_dataset"]
+__all__ = ["__version__", "configure_logging", "disable_logging", "get_dataset"]

--- a/src/magpylib_material_response/demag.py
+++ b/src/magpylib_material_response/demag.py
@@ -2,33 +2,18 @@
 
 from __future__ import annotations
 
-import sys
 from collections import Counter
 
 import magpylib as magpy
 import numpy as np
-from loguru import logger
 from magpylib._src.obj_classes.class_BaseExcitations import BaseCurrent, BaseMagnet
 from magpylib.magnet import Cuboid
 from scipy.spatial.transform import Rotation as R
 
+from magpylib_material_response.logging_config import get_logger
 from magpylib_material_response.utils import timelog
 
-config = {
-    "handlers": [
-        {
-            "sink": sys.stdout,
-            "colorize": True,
-            "format": (
-                "<magenta>{time:YYYY-MM-DD at HH:mm:ss}</magenta>"
-                " | <level>{level:^8}</level>"
-                " | <cyan>{function}</cyan>"
-                " | <yellow>{extra}</yellow> {level.icon:<2} {message}"
-            ),
-        },
-    ],
-}
-logger.configure(**config)
+logger = get_logger("magpylib_material_response.demag")
 
 
 def get_susceptibilities(sources, susceptibility=None):
@@ -272,14 +257,16 @@ def filter_distance(
                 "dimension": np.repeat(dim0, len(src_list), axis=0)[mask],
             }
         dsf = sum(mask) / len(mask) * 100
-    log_msg = (
-        "Interaction pairs left after distance factor filtering: "
-        f"<blue>{dsf:.2f}%</blue>"
-    )
     if dsf == 0:
-        logger.opt(colors=True).warning(log_msg)
+        logger.warning(
+            "No interaction pairs left after distance factor filtering",
+            percentage=f"{dsf:.2f}%"
+        )
     else:
-        logger.opt(colors=True).success(log_msg)
+        logger.info(
+            "Interaction pairs left after distance factor filtering",
+            percentage=f"{dsf:.2f}%"
+        )
     out = [mask]
     if return_params:
         out.append(params)
@@ -304,25 +291,25 @@ def match_pairs(src_list, min_log_time=1):
         len_src = len(src_list)
         num_of_pairs = len_src**2
         with logger.contextualize(task="Match interactions pairs"):
-            logger.info("position")
+            logger.debug("Computing position differences")
             pos2 = np.tile(pos0, (len_src, 1)) - np.repeat(pos0, len_src, axis=0)
-            logger.info("orientation")
+            logger.debug("Computing orientation differences")
             rotQ2a = np.tile(rotQ0, (len_src, 1)).reshape((num_of_pairs, -1))
             rotQ2b = np.repeat(rotQ0, len_src, axis=0).reshape((num_of_pairs, -1))
-            logger.info("dimension")
+            logger.debug("Computing dimension differences")
             dim2 = np.tile(dim0, (len_src, 1)) - np.repeat(dim0, len_src, axis=0)
-            logger.info("concatenate properties")
+            logger.debug("Concatenating properties for comparison")
             prop = (np.concatenate([pos2, rotQ2a, rotQ2b, dim2], axis=1) + 1e-9).round(
                 8
             )
-            logger.info("find unique indices")
+            logger.debug("Finding unique interaction pairs")
             _, unique_inds, unique_inv_inds = np.unique(
                 prop, return_index=True, return_inverse=True, axis=0
             )
             perc = len(unique_inds) / len(unique_inv_inds) * 100
-            logger.opt(colors=True).info(
-                "Interaction pairs left after pair matching filtering: "
-                f"<blue>{perc:.2f}%</blue>"
+            logger.info(
+                "Interaction pairs left after pair matching filtering",
+                percentage=f"{perc:.2f}%"
             )
 
         params = {

--- a/src/magpylib_material_response/demag.py
+++ b/src/magpylib_material_response/demag.py
@@ -395,10 +395,11 @@ def apply_demag(
         if not isinstance(src, BaseMagnet | BaseCurrent | magpy.Sensor)
     ]
     if others_list:
+        counts_others = Counter(s.__class__.__name__ for s in others_list)
+        counts_str = ", ".join(f"{count} {name}" for name, count in counts_others.items())
         msg = (
             "Only Magnet and Current sources supported. "
-            "Incompatible objects found: "
-            f"{Counter(s.__class__.__name__ for s in others_list)}"
+            f"Incompatible objects found: {counts_str}"
         )
         raise TypeError(msg)
     n = len(magnets_list)
@@ -406,9 +407,11 @@ def apply_demag(
     inplace_str = f"""{" (inplace)" if inplace else ""}"""
     lbl = collection.style.label
     coll_str = lbl if lbl else str(collection)
+    # Create a clean message without problematic formatting characters
+    counts_str = ", ".join(f"{count} {name}" for name, count in counts.items())
     demag_msg = (
         f"Demagnetization{inplace_str} of <blue>{coll_str}</blue>"
-        f" with {n} cells - {counts}"
+        f" with {n} cells ({counts_str})"
     )
     with timelog(demag_msg, min_log_time=min_log_time):
         # set up mr

--- a/src/magpylib_material_response/demag.py
+++ b/src/magpylib_material_response/demag.py
@@ -209,7 +209,9 @@ def demag_tensor(
                         H_unit_pol = []
                         for split_ind, src_list_subset in enumerate(src_list_split):
                             logger.info(
-                                f"Sources subset {split_ind + 1}/{len(src_list_split)}"
+                                "Sources subset {subset_num}/{total_subsets}",
+                                subset_num=split_ind + 1,
+                                total_subsets=len(src_list_split),
                             )
                             if src_list_subset.size > 0:
                                 H_unit_pol.append(

--- a/src/magpylib_material_response/demag.py
+++ b/src/magpylib_material_response/demag.py
@@ -260,12 +260,12 @@ def filter_distance(
     if dsf == 0:
         logger.warning(
             "No interaction pairs left after distance factor filtering",
-            percentage=f"{dsf:.2f}%"
+            percentage=f"{dsf:.2f}%",
         )
     else:
         logger.info(
             "Interaction pairs left after distance factor filtering",
-            percentage=f"{dsf:.2f}%"
+            percentage=f"{dsf:.2f}%",
         )
     out = [mask]
     if return_params:
@@ -309,7 +309,7 @@ def match_pairs(src_list, min_log_time=1):
             perc = len(unique_inds) / len(unique_inv_inds) * 100
             logger.info(
                 "Interaction pairs left after pair matching filtering",
-                percentage=f"{perc:.2f}%"
+                percentage=f"{perc:.2f}%",
             )
 
         params = {

--- a/src/magpylib_material_response/demag.py
+++ b/src/magpylib_material_response/demag.py
@@ -396,7 +396,9 @@ def apply_demag(
     ]
     if others_list:
         counts_others = Counter(s.__class__.__name__ for s in others_list)
-        counts_str = ", ".join(f"{count} {name}" for name, count in counts_others.items())
+        counts_str = ", ".join(
+            f"{count} {name}" for name, count in counts_others.items()
+        )
         msg = (
             "Only Magnet and Current sources supported. "
             f"Incompatible objects found: {counts_str}"

--- a/src/magpylib_material_response/demag.py
+++ b/src/magpylib_material_response/demag.py
@@ -6,14 +6,12 @@ from collections import Counter
 
 import magpylib as magpy
 import numpy as np
+from loguru import logger
 from magpylib._src.obj_classes.class_BaseExcitations import BaseCurrent, BaseMagnet
 from magpylib.magnet import Cuboid
 from scipy.spatial.transform import Rotation as R
 
-from magpylib_material_response.logging_config import get_logger
 from magpylib_material_response.utils import timelog
-
-logger = get_logger("magpylib_material_response.demag")
 
 
 def get_susceptibilities(sources, susceptibility=None):
@@ -128,7 +126,7 @@ def demag_tensor(
     pairs_matching=False,
     split=False,
     max_dist=0,
-    min_log_time=1,
+    min_log_time=None,
 ):
     """
     Compute the demagnetization tensor T based on point matching (see Chadbec 2006)
@@ -229,7 +227,7 @@ def demag_tensor(
 def filter_distance(
     src_list,
     max_dist,
-    min_log_time=1,
+    min_log_time=None,
     return_params=False,
     return_base_geo=False,
 ):
@@ -279,7 +277,7 @@ def filter_distance(
     return tuple(out)
 
 
-def match_pairs(src_list, min_log_time=1):
+def match_pairs(src_list, min_log_time=None):
     """match all pairs of sources from `src_list`"""
     with timelog("Pairs matching", min_log_time=min_log_time):
         all_cuboids = all(isinstance(src, Cuboid) for src in src_list)
@@ -330,7 +328,7 @@ def apply_demag(
     pairs_matching=False,
     max_dist=0,
     split=1,
-    min_log_time=1,
+    min_log_time=None,
     style=None,
 ):
     """
@@ -368,7 +366,9 @@ def apply_demag(
 
     min_log_time:
         Minimum logging time in seconds. If computation time is below this value, step
-        will not be logged.
+        will not be logged. If ``None`` (default), the value set by
+        :func:`magpylib_material_response.configure_logging` is used
+        (``1.0`` s by default).
 
     style: dict
         Set collection style. If `inplace=False` only affects the copied collection
@@ -411,11 +411,9 @@ def apply_demag(
     inplace_str = f"""{" (inplace)" if inplace else ""}"""
     lbl = collection.style.label
     coll_str = lbl if lbl else str(collection)
-    # Create a clean message without problematic formatting characters
     counts_str = ", ".join(f"{count} {name}" for name, count in counts.items())
     demag_msg = (
-        f"Demagnetization{inplace_str} of <blue>{coll_str}</blue>"
-        f" with {n} cells ({counts_str})"
+        f"Demagnetization{inplace_str} of {coll_str} with {n} cells ({counts_str})"
     )
     with timelog(demag_msg, min_log_time=min_log_time):
         # set up mr
@@ -468,7 +466,7 @@ def apply_demag(
         Q = np.eye(3 * n) - np.matmul(S, T)
 
         # determine new polarization vectors
-        with timelog("Solving of linear system", min_log_time=1):
+        with timelog("Solving of linear system", min_log_time=min_log_time):
             pol_new = np.linalg.solve(Q, pol_total + np.matmul(S, H_ext))
 
         pol_new = np.reshape(pol_new, (n, 3), order="F")

--- a/src/magpylib_material_response/demag.py
+++ b/src/magpylib_material_response/demag.py
@@ -6,14 +6,12 @@ from collections import Counter
 
 import magpylib as magpy
 import numpy as np
+from loguru import logger
 from magpylib._src.obj_classes.class_BaseExcitations import BaseCurrent, BaseMagnet
 from magpylib.magnet import Cuboid
 from scipy.spatial.transform import Rotation as R
 
-from magpylib_material_response.logging_config import get_logger
 from magpylib_material_response.utils import timelog
-
-logger = get_logger("magpylib_material_response.demag")
 
 
 def get_susceptibilities(sources, susceptibility=None):
@@ -128,7 +126,7 @@ def demag_tensor(
     pairs_matching=False,
     split=False,
     max_dist=0,
-    min_log_time=1,
+    min_log_time=None,
 ):
     """
     Compute the demagnetization tensor T based on point matching (see Chadbec 2006)
@@ -229,7 +227,7 @@ def demag_tensor(
 def filter_distance(
     src_list,
     max_dist,
-    min_log_time=1,
+    min_log_time=None,
     return_params=False,
     return_base_geo=False,
 ):
@@ -279,7 +277,7 @@ def filter_distance(
     return tuple(out)
 
 
-def match_pairs(src_list, min_log_time=1):
+def match_pairs(src_list, min_log_time=None):
     """match all pairs of sources from `src_list`"""
     with timelog("Pairs matching", min_log_time=min_log_time):
         all_cuboids = all(isinstance(src, Cuboid) for src in src_list)
@@ -330,7 +328,7 @@ def apply_demag(
     pairs_matching=False,
     max_dist=0,
     split=1,
-    min_log_time=1,
+    min_log_time=None,
     style=None,
 ):
     """
@@ -368,7 +366,9 @@ def apply_demag(
 
     min_log_time:
         Minimum logging time in seconds. If computation time is below this value, step
-        will not be logged.
+        will not be logged. If ``None`` (default), the value set by
+        :func:`magpylib_material_response.configure_logging` is used
+        (``1.0`` s by default).
 
     style: dict
         Set collection style. If `inplace=False` only affects the copied collection
@@ -411,10 +411,9 @@ def apply_demag(
     inplace_str = f"""{" (inplace)" if inplace else ""}"""
     lbl = collection.style.label
     coll_str = lbl if lbl else str(collection)
-    # Create a clean message without problematic formatting characters
     counts_str = ", ".join(f"{count} {name}" for name, count in counts.items())
     demag_msg = (
-        f"Demagnetization{inplace_str} of <blue>{coll_str}</blue>"
+        f"Demagnetization{inplace_str} of {coll_str}"
         f" with {n} cells ({counts_str})"
     )
     with timelog(demag_msg, min_log_time=min_log_time):
@@ -468,7 +467,7 @@ def apply_demag(
         Q = np.eye(3 * n) - np.matmul(S, T)
 
         # determine new polarization vectors
-        with timelog("Solving of linear system", min_log_time=1):
+        with timelog("Solving of linear system", min_log_time=min_log_time):
             pol_new = np.linalg.solve(Q, pol_total + np.matmul(S, H_ext))
 
         pol_new = np.reshape(pol_new, (n, 3), order="F")

--- a/src/magpylib_material_response/demag.py
+++ b/src/magpylib_material_response/demag.py
@@ -413,8 +413,7 @@ def apply_demag(
     coll_str = lbl if lbl else str(collection)
     counts_str = ", ".join(f"{count} {name}" for name, count in counts.items())
     demag_msg = (
-        f"Demagnetization{inplace_str} of {coll_str}"
-        f" with {n} cells ({counts_str})"
+        f"Demagnetization{inplace_str} of {coll_str} with {n} cells ({counts_str})"
     )
     with timelog(demag_msg, min_log_time=min_log_time):
         # set up mr

--- a/src/magpylib_material_response/logging_config.py
+++ b/src/magpylib_material_response/logging_config.py
@@ -1,0 +1,110 @@
+"""
+Centralized logging configuration for magpylib-material-response.
+
+This module provides a proper logging setup that:
+- Uses named loggers with package hierarchy
+- Allows user configuration through environment variables
+- Provides sensible defaults for library usage
+- Avoids forcing output to stdout unless explicitly requested
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from loguru import logger
+
+
+def get_logger(name: str | None = None):
+    """
+    Get a named logger for the package.
+    
+    Parameters
+    ----------
+    name : str, optional
+        Logger name. If None, uses the package root logger.
+        
+    Returns
+    -------
+    loguru.Logger
+        Configured logger instance
+    """
+    if name is None:
+        name = "magpylib_material_response"
+    return logger.bind(module=name)
+
+
+def configure_logging(
+    level: str | None = None,
+    enable_colors: bool | None = None,
+    show_time: bool | None = None,
+    sink=None,
+) -> None:
+    """
+    Configure logging for the package.
+    
+    This function should be called by users who want to see logging output
+    from the library. By default, the library doesn't output logs unless
+    explicitly configured.
+    
+    Parameters
+    ----------
+    level : str, optional
+        Log level. Defaults to INFO. Can be overridden with MAGPYLIB_LOG_LEVEL env var.
+    enable_colors : bool, optional
+        Enable colored output. Defaults to True for interactive environments.
+        Can be overridden with MAGPYLIB_LOG_COLORS env var.
+    show_time : bool, optional
+        Show timestamps in log messages. Defaults to True.
+        Can be overridden with MAGPYLIB_LOG_TIME env var.
+    sink : optional
+        Log sink. Defaults to sys.stderr. Use sys.stdout for stdout output.
+    """
+    # Remove existing handlers to avoid duplicates
+    logger.remove()
+    
+    # Get configuration from environment or use defaults
+    if level is None:
+        level = os.getenv("MAGPYLIB_LOG_LEVEL", "INFO")
+    
+    if enable_colors is None:
+        enable_colors = os.getenv("MAGPYLIB_LOG_COLORS", "true").lower() in ("true", "1", "yes")
+    
+    if show_time is None:
+        show_time = os.getenv("MAGPYLIB_LOG_TIME", "true").lower() in ("true", "1", "yes")
+    
+    if sink is None:
+        sink = sys.stderr
+    
+    # Build format string
+    time_part = "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | " if show_time else ""
+    format_str = (
+        f"{time_part}"
+        "<level>{level:^8}</level> | "
+        "<cyan>{extra[module]}</cyan> | "
+        "{level.icon:<2} {message}"
+    )
+    
+    # Configure the logger
+    logger.add(
+        sink,
+        level=level,
+        format=format_str,
+        colorize=enable_colors,
+        filter=lambda record: (
+            record["extra"].get("module", "").startswith("magpylib_material_response") or 
+            record.get("name", "").startswith("magpylib_material_response")
+        )
+    )
+
+
+def disable_logging() -> None:
+    """Disable all logging output from the package."""
+    logger.remove()
+    logger.add(sink=lambda _: None, level="CRITICAL")  # Sink that does nothing
+
+
+# Set up a default minimal configuration that doesn't output anything
+# Users need to call configure_logging() to see logs
+disable_logging()

--- a/src/magpylib_material_response/logging_config.py
+++ b/src/magpylib_material_response/logging_config.py
@@ -87,8 +87,12 @@ def configure_logging(
 
     # Custom format function to display structured data cleanly
     def format_record(record):
-        time_part = f"<green>{record['time'].strftime('%Y-%m-%d %H:%M:%S')}</green> | " if show_time else ""
-        
+        time_part = (
+            f"<green>{record['time'].strftime('%Y-%m-%d %H:%M:%S')}</green> | "
+            if show_time
+            else ""
+        )
+
         # Base format
         base = (
             f"{time_part}"
@@ -96,18 +100,18 @@ def configure_logging(
             f"<cyan>{record['extra'].get('module', 'unknown')}</cyan> | "
             f"{record['level'].icon:<2} {record['message']}"
         )
-        
+
         # Add extra context (excluding 'module' since it's already shown)
         extra_items = []
-        for key, value in record['extra'].items():
-            if key != 'module':
+        for key, value in record["extra"].items():
+            if key != "module":
                 extra_items.append(f"<dim>{key}={value}</dim>")
-        
+
         if extra_items:
             base += " | " + " | ".join(extra_items)
-        
+
         return base + "\n"
-    
+
     format_str = format_record
 
     # Configure the logger

--- a/src/magpylib_material_response/logging_config.py
+++ b/src/magpylib_material_response/logging_config.py
@@ -19,12 +19,12 @@ from loguru import logger
 def get_logger(name: str | None = None):
     """
     Get a named logger for the package.
-    
+
     Parameters
     ----------
     name : str, optional
         Logger name. If None, uses the package root logger.
-        
+
     Returns
     -------
     loguru.Logger
@@ -43,11 +43,11 @@ def configure_logging(
 ) -> None:
     """
     Configure logging for the package.
-    
+
     This function should be called by users who want to see logging output
     from the library. By default, the library doesn't output logs unless
     explicitly configured.
-    
+
     Parameters
     ----------
     level : str, optional
@@ -63,20 +63,28 @@ def configure_logging(
     """
     # Remove existing handlers to avoid duplicates
     logger.remove()
-    
+
     # Get configuration from environment or use defaults
     if level is None:
         level = os.getenv("MAGPYLIB_LOG_LEVEL", "INFO")
-    
+
     if enable_colors is None:
-        enable_colors = os.getenv("MAGPYLIB_LOG_COLORS", "true").lower() in ("true", "1", "yes")
-    
+        enable_colors = os.getenv("MAGPYLIB_LOG_COLORS", "true").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+
     if show_time is None:
-        show_time = os.getenv("MAGPYLIB_LOG_TIME", "true").lower() in ("true", "1", "yes")
-    
+        show_time = os.getenv("MAGPYLIB_LOG_TIME", "true").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+
     if sink is None:
         sink = sys.stderr
-    
+
     # Build format string
     time_part = "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | " if show_time else ""
     format_str = (
@@ -85,7 +93,7 @@ def configure_logging(
         "<cyan>{extra[module]}</cyan> | "
         "{level.icon:<2} {message}"
     )
-    
+
     # Configure the logger
     logger.add(
         sink,
@@ -93,9 +101,9 @@ def configure_logging(
         format=format_str,
         colorize=enable_colors,
         filter=lambda record: (
-            record["extra"].get("module", "").startswith("magpylib_material_response") or 
-            record.get("name", "").startswith("magpylib_material_response")
-        )
+            record["extra"].get("module", "").startswith("magpylib_material_response")
+            or record.get("name", "").startswith("magpylib_material_response")
+        ),
     )
 
 

--- a/src/magpylib_material_response/logging_config.py
+++ b/src/magpylib_material_response/logging_config.py
@@ -38,9 +38,7 @@ _DEFAULT_FORMAT = (
     "<level>{message}</level>"
 )
 _NO_TIME_FORMAT = (
-    "<level>{level: <8}</level> | "
-    "<cyan>{name}</cyan> | "
-    "<level>{message}</level>"
+    "<level>{level: <8}</level> | <cyan>{name}</cyan> | <level>{message}</level>"
 )
 
 # Track sinks added by this module so we can replace them on reconfigure

--- a/src/magpylib_material_response/logging_config.py
+++ b/src/magpylib_material_response/logging_config.py
@@ -1,138 +1,150 @@
 """
 Centralized logging configuration for magpylib-material-response.
 
-This module provides a proper logging setup that:
-- Uses named loggers with package hierarchy
-- Allows user configuration through environment variables
-- Provides sensible defaults for library usage
-- Avoids forcing output to stdout unless explicitly requested
+This module follows the loguru library-friendly recipe:
+
+* The package is *disabled* at import time via ``logger.disable(__name__)`` so
+  that simply importing :mod:`magpylib_material_response` never modifies the
+  user's loguru configuration nor produces any output.
+* Calling :func:`configure_logging` enables the package and adds a sink
+  *only if the user has not already configured one for this package*.
+* :func:`disable_logging` re-disables the package without touching any other
+  loguru sinks.
+
+This way the library never calls ``logger.remove()`` and never overrides sinks
+configured by the application or by other libraries.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+from contextlib import suppress
+from typing import Any
 
 from loguru import logger
 
+PACKAGE = "magpylib_material_response"
 
-def get_logger(name: str | None = None):
-    """
-    Get a named logger for the package.
+# Default minimum duration (seconds) for `timelog()` to emit a record.
+# Updated by `configure_logging(min_log_time=...)` and consulted by
+# `magpylib_material_response.utils.timelog` when its own argument is None.
+DEFAULT_MIN_LOG_TIME: float = 1.0
 
-    Parameters
-    ----------
-    name : str, optional
-        Logger name. If None, uses the package root logger.
+_DEFAULT_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan> | "
+    "<level>{message}</level>"
+)
+_NO_TIME_FORMAT = (
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan> | "
+    "<level>{message}</level>"
+)
 
-    Returns
-    -------
-    loguru.Logger
-        Configured logger instance
-    """
-    if name is None:
-        name = "magpylib_material_response"
-    return logger.bind(module=name)
+# Track sinks added by this module so we can replace them on reconfigure
+# without disturbing sinks configured by the application.
+_handler_ids: list[int] = []
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return val.strip().lower() in ("true", "1", "yes", "on")
 
 
 def configure_logging(
     level: str | None = None,
     enable_colors: bool | None = None,
     show_time: bool | None = None,
-    sink=None,
-) -> None:
+    sink: Any = None,
+    min_log_time: float | None = None,
+) -> int:
     """
-    Configure logging for the package.
+    Enable and configure logging for the package.
 
-    This function should be called by users who want to see logging output
-    from the library. By default, the library doesn't output logs unless
-    explicitly configured.
+    The library is silent by default. Call this function from an application
+    to see log messages.
 
     Parameters
     ----------
     level : str, optional
-        Log level. Defaults to INFO. Can be overridden with MAGPYLIB_LOG_LEVEL env var.
+        Log level. Defaults to ``"INFO"``. Can be overridden with the
+        ``MAGPYLIB_LOG_LEVEL`` environment variable.
     enable_colors : bool, optional
-        Enable colored output. Defaults to True for interactive environments.
-        Can be overridden with MAGPYLIB_LOG_COLORS env var.
+        Enable colored output. Defaults to ``True``. Can be overridden with
+        ``MAGPYLIB_LOG_COLORS``.
     show_time : bool, optional
-        Show timestamps in log messages. Defaults to True.
-        Can be overridden with MAGPYLIB_LOG_TIME env var.
+        Show timestamps. Defaults to ``True``. Can be overridden with
+        ``MAGPYLIB_LOG_TIME``.
     sink : optional
-        Log sink. Defaults to sys.stderr. Use sys.stdout for stdout output.
-    """
-    # Remove existing handlers to avoid duplicates
-    logger.remove()
+        Loguru sink (file path, stream, or callable). Defaults to
+        ``sys.stderr``, following the convention for library logs.
+    min_log_time : float, optional
+        Default minimum duration (in seconds) for ``timelog()`` blocks to
+        emit a record. Steps that complete faster than this are not logged.
+        Functions like ``apply_demag`` honour this value when their own
+        ``min_log_time`` argument is left at its default. Can be overridden
+        with ``MAGPYLIB_LOG_MIN_TIME``. Defaults to ``1.0``.
 
-    # Get configuration from environment or use defaults
+    Returns
+    -------
+    int
+        The id of the added sink, so callers can remove it with
+        ``loguru.logger.remove(handler_id)`` if desired.
+    """
     if level is None:
         level = os.getenv("MAGPYLIB_LOG_LEVEL", "INFO")
-
     if enable_colors is None:
-        enable_colors = os.getenv("MAGPYLIB_LOG_COLORS", "true").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
-
+        enable_colors = _env_bool("MAGPYLIB_LOG_COLORS", True)
     if show_time is None:
-        show_time = os.getenv("MAGPYLIB_LOG_TIME", "true").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
-
+        show_time = _env_bool("MAGPYLIB_LOG_TIME", True)
     if sink is None:
-        sink = sys.stdout
+        sink = sys.stderr
+    if min_log_time is None:
+        env_val = os.getenv("MAGPYLIB_LOG_MIN_TIME")
+        min_log_time = float(env_val) if env_val is not None else 1.0
 
-    # Custom format function to display structured data cleanly
-    def format_record(record):
-        time_part = (
-            f"<green>{record['time'].strftime('%Y-%m-%d %H:%M:%S')}</green> | "
-            if show_time
-            else ""
-        )
+    global DEFAULT_MIN_LOG_TIME
+    DEFAULT_MIN_LOG_TIME = float(min_log_time)
 
-        # Base format
-        base = (
-            f"{time_part}"
-            f"<level>{record['level'].name:^8}</level> | "
-            f"<cyan>{record['extra'].get('module', 'unknown')}</cyan> | "
-            f"{record['level'].icon:<2} {record['message']}"
-        )
+    # Remove only sinks previously added by this module; leave other sinks
+    # (configured by the application) untouched.
+    for hid in _handler_ids:
+        with suppress(ValueError):
+            logger.remove(hid)
+    _handler_ids.clear()
 
-        # Add extra context (excluding 'module' since it's already shown)
-        extra_items = []
-        for key, value in record["extra"].items():
-            if key != "module":
-                extra_items.append(f"<dim>{key}={value}</dim>")
-
-        if extra_items:
-            base += " | " + " | ".join(extra_items)
-
-        return base + "\n"
-
-    format_str = format_record
-
-    # Configure the logger
-    logger.add(
+    fmt = _DEFAULT_FORMAT if show_time else _NO_TIME_FORMAT
+    hid = logger.add(
         sink,
         level=level,
-        format=format_str,
+        format=fmt,
         colorize=enable_colors,
-        filter=lambda record: (
-            record["extra"].get("module", "").startswith("magpylib_material_response")
-            or record.get("name", "").startswith("magpylib_material_response")
-        ),
+        filter=PACKAGE,  # only records emitted from this package's modules
     )
+    _handler_ids.append(hid)
+    logger.enable(PACKAGE)
+    return hid
 
 
 def disable_logging() -> None:
-    """Disable all logging output from the package."""
-    logger.remove()
-    logger.add(sink=lambda _: None, level="CRITICAL")  # Sink that does nothing
+    """
+    Disable logging output from the package.
+
+    Removes any sinks previously added by :func:`configure_logging` and
+    disables the package via ``logger.disable``. Other sinks configured by the
+    application are left untouched.
+    """
+    for hid in _handler_ids:
+        with suppress(ValueError):
+            logger.remove(hid)
+    _handler_ids.clear()
+    logger.disable(PACKAGE)
 
 
-# Set up a default minimal configuration that doesn't output anything
-# Users need to call configure_logging() to see logs
-disable_logging()
+# Silent by default: do not emit any records from this package until
+# `configure_logging()` is called. This does NOT remove user sinks.
+logger.disable(PACKAGE)

--- a/src/magpylib_material_response/logging_config.py
+++ b/src/magpylib_material_response/logging_config.py
@@ -1,138 +1,158 @@
 """
 Centralized logging configuration for magpylib-material-response.
 
-This module provides a proper logging setup that:
-- Uses named loggers with package hierarchy
-- Allows user configuration through environment variables
-- Provides sensible defaults for library usage
-- Avoids forcing output to stdout unless explicitly requested
+This module follows the loguru library-friendly recipe:
+
+* The package is *disabled* at import time via ``logger.disable(__name__)`` so
+  that simply importing :mod:`magpylib_material_response` never modifies the
+  user's loguru configuration nor produces any output.
+* Calling :func:`configure_logging` enables the package and adds a sink
+  *only if the user has not already configured one for this package*.
+* :func:`disable_logging` re-disables the package without touching any other
+  loguru sinks.
+
+This way the library never calls ``logger.remove()`` and never overrides sinks
+configured by the application or by other libraries.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+from contextlib import suppress
+from typing import Any
 
 from loguru import logger
 
+PACKAGE = "magpylib_material_response"
 
-def get_logger(name: str | None = None):
-    """
-    Get a named logger for the package.
+# Default minimum duration (seconds) for `timelog()` to emit a record.
+# Updated by `configure_logging(min_log_time=...)` and consulted by
+# `magpylib_material_response.utils.timelog` when its own argument is None.
+# Stored in a mutable dict so `configure_logging` can update it without a
+# ``global`` statement; exposed as ``logging_config.DEFAULT_MIN_LOG_TIME``
+# via the module-level ``__getattr__`` below (PEP 562).
+_defaults: dict[str, float] = {"DEFAULT_MIN_LOG_TIME": 1.0}
 
-    Parameters
-    ----------
-    name : str, optional
-        Logger name. If None, uses the package root logger.
 
-    Returns
-    -------
-    loguru.Logger
-        Configured logger instance
-    """
-    if name is None:
-        name = "magpylib_material_response"
-    return logger.bind(module=name)
+def __getattr__(name: str) -> Any:
+    if name in _defaults:
+        return _defaults[name]
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+_DEFAULT_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan> | "
+    "<level>{message}</level>"
+)
+_NO_TIME_FORMAT = (
+    "<level>{level: <8}</level> | <cyan>{name}</cyan> | <level>{message}</level>"
+)
+
+# Track sinks added by this module so we can replace them on reconfigure
+# without disturbing sinks configured by the application.
+_handler_ids: list[int] = []
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return val.strip().lower() in ("true", "1", "yes", "on")
 
 
 def configure_logging(
     level: str | None = None,
     enable_colors: bool | None = None,
     show_time: bool | None = None,
-    sink=None,
-) -> None:
+    sink: Any = None,
+    min_log_time: float | None = None,
+) -> int:
     """
-    Configure logging for the package.
+    Enable and configure logging for the package.
 
-    This function should be called by users who want to see logging output
-    from the library. By default, the library doesn't output logs unless
-    explicitly configured.
+    The library is silent by default. Call this function from an application
+    to see log messages.
 
     Parameters
     ----------
     level : str, optional
-        Log level. Defaults to INFO. Can be overridden with MAGPYLIB_LOG_LEVEL env var.
+        Log level. Defaults to ``"INFO"``. Can be overridden with the
+        ``MAGPYLIB_LOG_LEVEL`` environment variable.
     enable_colors : bool, optional
-        Enable colored output. Defaults to True for interactive environments.
-        Can be overridden with MAGPYLIB_LOG_COLORS env var.
+        Enable colored output. Defaults to ``True``. Can be overridden with
+        ``MAGPYLIB_LOG_COLORS``.
     show_time : bool, optional
-        Show timestamps in log messages. Defaults to True.
-        Can be overridden with MAGPYLIB_LOG_TIME env var.
+        Show timestamps. Defaults to ``True``. Can be overridden with
+        ``MAGPYLIB_LOG_TIME``.
     sink : optional
-        Log sink. Defaults to sys.stderr. Use sys.stdout for stdout output.
-    """
-    # Remove existing handlers to avoid duplicates
-    logger.remove()
+        Loguru sink (file path, stream, or callable). Defaults to
+        ``sys.stderr``, following the convention for library logs.
+    min_log_time : float, optional
+        Default minimum duration (in seconds) for ``timelog()`` blocks to
+        emit a record. Steps that complete faster than this are not logged.
+        Functions like ``apply_demag`` honour this value when their own
+        ``min_log_time`` argument is left at its default. Can be overridden
+        with ``MAGPYLIB_LOG_MIN_TIME``. Defaults to ``1.0``.
 
-    # Get configuration from environment or use defaults
+    Returns
+    -------
+    int
+        The id of the added sink, so callers can remove it with
+        ``loguru.logger.remove(handler_id)`` if desired.
+    """
     if level is None:
         level = os.getenv("MAGPYLIB_LOG_LEVEL", "INFO")
-
     if enable_colors is None:
-        enable_colors = os.getenv("MAGPYLIB_LOG_COLORS", "true").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
-
+        enable_colors = _env_bool("MAGPYLIB_LOG_COLORS", True)
     if show_time is None:
-        show_time = os.getenv("MAGPYLIB_LOG_TIME", "true").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
-
+        show_time = _env_bool("MAGPYLIB_LOG_TIME", True)
     if sink is None:
-        sink = sys.stdout
+        sink = sys.stderr
+    if min_log_time is None:
+        env_val = os.getenv("MAGPYLIB_LOG_MIN_TIME")
+        min_log_time = float(env_val) if env_val is not None else 1.0
 
-    # Custom format function to display structured data cleanly
-    def format_record(record):
-        time_part = (
-            f"<green>{record['time'].strftime('%Y-%m-%d %H:%M:%S')}</green> | "
-            if show_time
-            else ""
-        )
+    _defaults["DEFAULT_MIN_LOG_TIME"] = float(min_log_time)
 
-        # Base format
-        base = (
-            f"{time_part}"
-            f"<level>{record['level'].name:^8}</level> | "
-            f"<cyan>{record['extra'].get('module', 'unknown')}</cyan> | "
-            f"{record['level'].icon:<2} {record['message']}"
-        )
+    # Remove only sinks previously added by this module; leave other sinks
+    # (configured by the application) untouched.
+    for hid in _handler_ids:
+        with suppress(ValueError):
+            logger.remove(hid)
+    _handler_ids.clear()
 
-        # Add extra context (excluding 'module' since it's already shown)
-        extra_items = []
-        for key, value in record["extra"].items():
-            if key != "module":
-                extra_items.append(f"<dim>{key}={value}</dim>")
-
-        if extra_items:
-            base += " | " + " | ".join(extra_items)
-
-        return base + "\n"
-
-    format_str = format_record
-
-    # Configure the logger
-    logger.add(
+    fmt = _DEFAULT_FORMAT if show_time else _NO_TIME_FORMAT
+    hid = logger.add(
         sink,
         level=level,
-        format=format_str,
+        format=fmt,
         colorize=enable_colors,
-        filter=lambda record: (
-            record["extra"].get("module", "").startswith("magpylib_material_response")
-            or record.get("name", "").startswith("magpylib_material_response")
-        ),
+        filter=PACKAGE,  # only records emitted from this package's modules
     )
+    _handler_ids.append(hid)
+    logger.enable(PACKAGE)
+    return hid
 
 
 def disable_logging() -> None:
-    """Disable all logging output from the package."""
-    logger.remove()
-    logger.add(sink=lambda _: None, level="CRITICAL")  # Sink that does nothing
+    """
+    Disable logging output from the package.
+
+    Removes any sinks previously added by :func:`configure_logging` and
+    disables the package via ``logger.disable``. Other sinks configured by the
+    application are left untouched.
+    """
+    for hid in _handler_ids:
+        with suppress(ValueError):
+            logger.remove(hid)
+    _handler_ids.clear()
+    logger.disable(PACKAGE)
 
 
-# Set up a default minimal configuration that doesn't output anything
-# Users need to call configure_logging() to see logs
-disable_logging()
+# Silent by default: do not emit any records from this package until
+# `configure_logging()` is called. This does NOT remove user sinks.
+logger.disable(PACKAGE)

--- a/src/magpylib_material_response/meshing.py
+++ b/src/magpylib_material_response/meshing.py
@@ -429,9 +429,11 @@ def mesh_all(
     else:
         target_elems_by_child = [max(min_elems, target_elems)] * len(supported_objs)
     if incompatible_objs:
+        counts_incompatible = Counter(s.__class__.__name__ for s in incompatible_objs)
+        counts_str = ", ".join(f"{count} {name}" for name, count in counts_incompatible.items())
         msg = (
             "Incompatible objects found: "
-            f"{Counter(s.__class__.__name__ for s in incompatible_objs)}"
+            f"{counts_str}"
             f"\nSupported: {[s.__name__ for s in supported]}."
         )
         raise TypeError(msg)

--- a/src/magpylib_material_response/meshing.py
+++ b/src/magpylib_material_response/meshing.py
@@ -430,7 +430,9 @@ def mesh_all(
         target_elems_by_child = [max(min_elems, target_elems)] * len(supported_objs)
     if incompatible_objs:
         counts_incompatible = Counter(s.__class__.__name__ for s in incompatible_objs)
-        counts_str = ", ".join(f"{count} {name}" for name, count in counts_incompatible.items())
+        counts_str = ", ".join(
+            f"{count} {name}" for name, count in counts_incompatible.items()
+        )
         msg = (
             "Incompatible objects found: "
             f"{counts_str}"

--- a/src/magpylib_material_response/meshing.py
+++ b/src/magpylib_material_response/meshing.py
@@ -5,15 +5,17 @@ from itertools import product
 
 import magpylib as magpy
 import numpy as np
-from loguru import logger
 from magpylib._src.obj_classes.class_BaseExcitations import BaseCurrent
 from scipy.spatial.transform import Rotation as R
 
+from magpylib_material_response.logging_config import get_logger
 from magpylib_material_response.meshing_utils import (
     cells_from_dimension,
     get_volume,
     mask_inside,
 )
+
+logger = get_logger("magpylib_material_response.meshing")
 
 
 def _collection_from_obj_and_cells(obj, cells, **style_kwargs):
@@ -66,9 +68,11 @@ def mesh_Cuboid(cuboid, target_elems, verbose=False, **kwargs):
         nnn = target_elems
     elems = np.prod(nnn)
     if verbose:
-        logger.opt(colors=True).info(
-            f"Meshing Cuboid with <blue>{nnn[0]}x{nnn[1]}x{nnn[2]}={elems}</blue>"
-            f" elements (target={target_elems})"
+        logger.info(
+            "Meshing Cuboid",
+            dimensions=f"{nnn[0]}x{nnn[1]}x{nnn[2]}",
+            elements=elems,
+            target=target_elems
         )
 
     # secure input type
@@ -143,9 +147,11 @@ def mesh_Cylinder(cylinder, target_elems, verbose=False, **kwargs):
         nphi, nr, nh = target_elems
     elems = np.prod([nphi, nr, nh])
     if verbose:
-        logger.opt(colors=True).info(
-            f"Meshing CylinderSegement with <blue>{nphi}x{nr}x{nh}={elems}</blue>"
-            f" elements (target={target_elems})"
+        logger.info(
+            "Meshing CylinderSegment",
+            dimensions=f"{nphi}x{nr}x{nh}",
+            elements=elems,
+            target=target_elems
         )
     r = np.linspace(r1, r2, nr + 1)
     dh = h / nh

--- a/src/magpylib_material_response/meshing.py
+++ b/src/magpylib_material_response/meshing.py
@@ -72,7 +72,7 @@ def mesh_Cuboid(cuboid, target_elems, verbose=False, **kwargs):
             "Meshing Cuboid",
             dimensions=f"{nnn[0]}x{nnn[1]}x{nnn[2]}",
             elements=elems,
-            target=target_elems
+            target=target_elems,
         )
 
     # secure input type
@@ -151,7 +151,7 @@ def mesh_Cylinder(cylinder, target_elems, verbose=False, **kwargs):
             "Meshing CylinderSegment",
             dimensions=f"{nphi}x{nr}x{nh}",
             elements=elems,
-            target=target_elems
+            target=target_elems,
         )
     r = np.linspace(r1, r2, nr + 1)
     dh = h / nh

--- a/src/magpylib_material_response/meshing.py
+++ b/src/magpylib_material_response/meshing.py
@@ -244,7 +244,7 @@ def mesh_thin_CylinderSegment_with_cuboids(
         np.deg2rad(phi1) + dphi / 2, np.deg2rad(phi2) - dphi / 2, nphi
     )
     poss = np.array([x0 * np.cos(phi_vec), x0 * np.sin(phi_vec), np.zeros(nphi)]).T
-    rots = R.from_euler("z", phi_vec)
+    rots = R.from_rotvec(np.column_stack([np.zeros((nphi, 2)), phi_vec]))
     cells = []
     for z in np.linspace(-h / 2 + dh / 2, h / 2 - dh / 2, nh):
         for pos, orient in zip(poss, rots, strict=False):

--- a/src/magpylib_material_response/meshing.py
+++ b/src/magpylib_material_response/meshing.py
@@ -5,17 +5,15 @@ from itertools import product
 
 import magpylib as magpy
 import numpy as np
+from loguru import logger
 from magpylib._src.obj_classes.class_BaseExcitations import BaseCurrent
 from scipy.spatial.transform import Rotation as R
 
-from magpylib_material_response.logging_config import get_logger
 from magpylib_material_response.meshing_utils import (
     cells_from_dimension,
     get_volume,
     mask_inside,
 )
-
-logger = get_logger("magpylib_material_response.meshing")
 
 
 def _collection_from_obj_and_cells(obj, cells, **style_kwargs):

--- a/src/magpylib_material_response/polyline.py
+++ b/src/magpylib_material_response/polyline.py
@@ -43,7 +43,9 @@ def _find_circle_center_and_tangent_points(
     d = r / tan_theta
     if d > norm_bc * max_ratio or d > norm_ab * max_ratio:
         # rold, dold = r, d
-        logger.debug("Fillet parameters adjusted", r=r, d=d, norm_ab=norm_ab, norm_bc=norm_bc)
+        logger.debug(
+            "Fillet parameters adjusted", r=r, d=d, norm_ab=norm_ab, norm_bc=norm_bc
+        )
         d = min(norm_bc * max_ratio, norm_ab * max_ratio)
         r = d * tan_theta if theta > 0 else 0
         # warnings.warn(f"Radius {rold:.4g} is too big and has been reduced to {r:.4g}")

--- a/src/magpylib_material_response/polyline.py
+++ b/src/magpylib_material_response/polyline.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import numpy as np
-from loguru import logger
+
+from magpylib_material_response.logging_config import get_logger
+
+logger = get_logger("magpylib_material_response.polyline")
 
 
 def _find_circle_center_and_tangent_points(
@@ -40,7 +43,7 @@ def _find_circle_center_and_tangent_points(
     d = r / tan_theta
     if d > norm_bc * max_ratio or d > norm_ab * max_ratio:
         # rold, dold = r, d
-        logger.debug(f"r: {r}, d: {d}, norm_ab: {norm_ab}, norm_bc: {norm_bc}")
+        logger.debug("Fillet parameters adjusted", r=r, d=d, norm_ab=norm_ab, norm_bc=norm_bc)
         d = min(norm_bc * max_ratio, norm_ab * max_ratio)
         r = d * tan_theta if theta > 0 else 0
         # warnings.warn(f"Radius {rold:.4g} is too big and has been reduced to {r:.4g}")

--- a/src/magpylib_material_response/polyline.py
+++ b/src/magpylib_material_response/polyline.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
-
-from magpylib_material_response.logging_config import get_logger
-
-logger = get_logger("magpylib_material_response.polyline")
+from loguru import logger
 
 
 def _find_circle_center_and_tangent_points(

--- a/src/magpylib_material_response/utils.py
+++ b/src/magpylib_material_response/utils.py
@@ -66,9 +66,7 @@ def timelog(msg, min_log_time=1):
 
     if end > min_log_time:
         logger.info(
-            "Operation completed",
-            operation=msg,
-            duration_seconds=round(end, 3)
+            "Operation completed", operation=msg, duration_seconds=round(end, 3)
         )
 
 

--- a/src/magpylib_material_response/utils.py
+++ b/src/magpylib_material_response/utils.py
@@ -42,7 +42,7 @@ class ElapsedTimeThread(threading.Thread):
                 and time.time() - self.thread_start > self.min_log_time
                 and not self._msg_displayed
             ):
-                logger.info("Starting operation", operation=self.msg)
+                logger.info("🔄 Starting: {operation}", operation=self.msg)
                 self._msg_displayed = True
             # include a delay here so the thread doesn't uselessly thrash the CPU
             time.sleep(max(0.01, self.min_log_time / 5))
@@ -62,11 +62,13 @@ def timelog(msg, min_log_time=1):
         thread_timer.stop()
         thread_timer.join()
         if end is None:
-            logger.exception("Operation failed", operation=msg)
+            logger.exception("❌ Failed: {operation}", operation=msg)
 
     if end > min_log_time:
         logger.info(
-            "Operation completed", operation=msg, duration_seconds=round(end, 3)
+            "✅ Completed: {operation} in {duration}s", 
+            operation=msg, 
+            duration=round(end, 3)
         )
 
 

--- a/src/magpylib_material_response/utils.py
+++ b/src/magpylib_material_response/utils.py
@@ -66,9 +66,9 @@ def timelog(msg, min_log_time=1):
 
     if end > min_log_time:
         logger.info(
-            "✅ Completed: {operation} in {duration}s", 
-            operation=msg, 
-            duration=round(end, 3)
+            "✅ Completed: {operation} in {duration}s",
+            operation=msg,
+            duration=round(end, 3),
         )
 
 

--- a/src/magpylib_material_response/utils.py
+++ b/src/magpylib_material_response/utils.py
@@ -6,9 +6,12 @@ import warnings
 from contextlib import contextmanager
 
 import magpylib as magpy
-from loguru import logger
 from magpylib._src.obj_classes.class_BaseExcitations import BaseMagnet
 from scipy.spatial.transform import Rotation
+
+from magpylib_material_response.logging_config import get_logger
+
+logger = get_logger("magpylib_material_response.utils")
 
 
 class ElapsedTimeThread(threading.Thread):
@@ -39,7 +42,7 @@ class ElapsedTimeThread(threading.Thread):
                 and time.time() - self.thread_start > self.min_log_time
                 and not self._msg_displayed
             ):
-                logger.opt(colors=True).info(f"Start {self.msg}")
+                logger.info("Starting operation", operation=self.msg)
                 self._msg_displayed = True
             # include a delay here so the thread doesn't uselessly thrash the CPU
             time.sleep(max(0.01, self.min_log_time / 5))
@@ -59,11 +62,13 @@ def timelog(msg, min_log_time=1):
         thread_timer.stop()
         thread_timer.join()
         if end is None:
-            logger.opt(colors=True).exception(f"{msg} failed")
+            logger.exception("Operation failed", operation=msg)
 
     if end > min_log_time:
-        logger.opt(colors=True).success(
-            f"{msg} done<green> 🕑 {round(end, 3)}sec</green>"
+        logger.info(
+            "Operation completed",
+            operation=msg,
+            duration_seconds=round(end, 3)
         )
 
 

--- a/src/magpylib_material_response/utils.py
+++ b/src/magpylib_material_response/utils.py
@@ -6,23 +6,24 @@ import warnings
 from contextlib import contextmanager
 
 import magpylib as magpy
+from loguru import logger
 from magpylib._src.obj_classes.class_BaseExcitations import BaseMagnet
 from scipy.spatial.transform import Rotation
 
-from magpylib_material_response.logging_config import get_logger
-
-logger = get_logger("magpylib_material_response.utils")
+from magpylib_material_response import logging_config
 
 
 class ElapsedTimeThread(threading.Thread):
     """ "Stoppable thread that logs the time elapsed"""
 
-    def __init__(self, msg=None, min_log_time=1):
+    def __init__(self, msg=None, min_log_time=None):
         super().__init__()
         self._stop_event = threading.Event()
         self.thread_start = time.time()
         self.msg = msg
-        self.min_log_time = min_log_time
+        self.min_log_time = (
+            logging_config.DEFAULT_MIN_LOG_TIME if min_log_time is None else min_log_time
+        )
         self._msg_displayed = False
 
     def stop(self):
@@ -42,34 +43,41 @@ class ElapsedTimeThread(threading.Thread):
                 and time.time() - self.thread_start > self.min_log_time
                 and not self._msg_displayed
             ):
-                logger.info("🔄 Starting: {operation}", operation=self.msg)
+                logger.info("Starting: {operation}", operation=self.msg)
                 self._msg_displayed = True
             # include a delay here so the thread doesn't uselessly thrash the CPU
             time.sleep(max(0.01, self.min_log_time / 5))
 
 
 @contextmanager
-def timelog(msg, min_log_time=1):
-    """ "Measure and log time with loguru as context manager."""
+def timelog(msg, min_log_time=None):
+    """Measure and log time with loguru as context manager.
+
+    If ``min_log_time`` is None, the value set by
+    :func:`magpylib_material_response.configure_logging` (default ``1.0`` s)
+    is used.
+    """
+    if min_log_time is None:
+        min_log_time = logging_config.DEFAULT_MIN_LOG_TIME
     start = time.perf_counter()
-    end = None
     thread_timer = ElapsedTimeThread(msg=msg, min_log_time=min_log_time)
     thread_timer.start()
     try:
         yield
+    except Exception:
+        logger.opt(exception=True).error("Failed: {operation}", operation=msg)
+        raise
+    else:
         end = time.perf_counter() - start
+        if end > min_log_time:
+            logger.info(
+                "Completed: {operation} in {duration}s",
+                operation=msg,
+                duration=round(end, 3),
+            )
     finally:
         thread_timer.stop()
         thread_timer.join()
-        if end is None:
-            logger.exception("❌ Failed: {operation}", operation=msg)
-
-    if end > min_log_time:
-        logger.info(
-            "✅ Completed: {operation} in {duration}s",
-            operation=msg,
-            duration=round(end, 3),
-        )
 
 
 def serialize_recursive(obj, parent="warn"):

--- a/src/magpylib_material_response/utils.py
+++ b/src/magpylib_material_response/utils.py
@@ -6,23 +6,26 @@ import warnings
 from contextlib import contextmanager
 
 import magpylib as magpy
+from loguru import logger
 from magpylib._src.obj_classes.class_BaseExcitations import BaseMagnet
 from scipy.spatial.transform import Rotation
 
-from magpylib_material_response.logging_config import get_logger
-
-logger = get_logger("magpylib_material_response.utils")
+from magpylib_material_response import logging_config
 
 
 class ElapsedTimeThread(threading.Thread):
     """ "Stoppable thread that logs the time elapsed"""
 
-    def __init__(self, msg=None, min_log_time=1):
+    def __init__(self, msg=None, min_log_time=None):
         super().__init__()
         self._stop_event = threading.Event()
         self.thread_start = time.time()
         self.msg = msg
-        self.min_log_time = min_log_time
+        self.min_log_time = (
+            logging_config.DEFAULT_MIN_LOG_TIME
+            if min_log_time is None
+            else min_log_time
+        )
         self._msg_displayed = False
 
     def stop(self):
@@ -42,34 +45,65 @@ class ElapsedTimeThread(threading.Thread):
                 and time.time() - self.thread_start > self.min_log_time
                 and not self._msg_displayed
             ):
-                logger.info("🔄 Starting: {operation}", operation=self.msg)
+                logger.info("Starting: {operation}", operation=self.msg)
                 self._msg_displayed = True
             # include a delay here so the thread doesn't uselessly thrash the CPU
             time.sleep(max(0.01, self.min_log_time / 5))
 
 
+def format_duration(seconds):
+    """Format a duration in seconds using an appropriate unit.
+
+    Picks ns / µs / ms / s / m s / h m s based on magnitude so values
+    spanning many orders of magnitude stay readable.
+    """
+    if seconds < 0:
+        return f"-{format_duration(-seconds)}"
+    if seconds < 1e-6:
+        return f"{seconds * 1e9:.0f} ns"
+    if seconds < 1e-3:
+        return f"{seconds * 1e6:.3g} µs"
+    if seconds < 1.0:
+        return f"{seconds * 1e3:.3g} ms"
+    if seconds < 60.0:
+        return f"{seconds:.3g} s"
+    if seconds < 3600.0:
+        m, s = divmod(seconds, 60)
+        return f"{int(m)} m {s:04.1f} s"
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{int(h)} h {int(m):02d} m {int(s):02d} s"
+
+
 @contextmanager
-def timelog(msg, min_log_time=1):
-    """ "Measure and log time with loguru as context manager."""
+def timelog(msg, min_log_time=None):
+    """Measure and log time with loguru as context manager.
+
+    If ``min_log_time`` is None, the value set by
+    :func:`magpylib_material_response.configure_logging` (default ``1.0`` s)
+    is used.
+    """
+    if min_log_time is None:
+        min_log_time = logging_config.DEFAULT_MIN_LOG_TIME
     start = time.perf_counter()
-    end = None
     thread_timer = ElapsedTimeThread(msg=msg, min_log_time=min_log_time)
     thread_timer.start()
     try:
         yield
+    except Exception:
+        logger.opt(exception=True).error("Failed: {operation}", operation=msg)
+        raise
+    else:
         end = time.perf_counter() - start
+        if end > min_log_time:
+            logger.info(
+                "Completed: {operation} in {duration}",
+                operation=msg,
+                duration=format_duration(end),
+            )
     finally:
         thread_timer.stop()
         thread_timer.join()
-        if end is None:
-            logger.exception("❌ Failed: {operation}", operation=msg)
-
-    if end > min_log_time:
-        logger.info(
-            "✅ Completed: {operation} in {duration}s",
-            operation=msg,
-            duration=round(end, 3),
-        )
 
 
 def serialize_recursive(obj, parent="warn"):

--- a/src/magpylib_material_response/utils.py
+++ b/src/magpylib_material_response/utils.py
@@ -22,7 +22,9 @@ class ElapsedTimeThread(threading.Thread):
         self.thread_start = time.time()
         self.msg = msg
         self.min_log_time = (
-            logging_config.DEFAULT_MIN_LOG_TIME if min_log_time is None else min_log_time
+            logging_config.DEFAULT_MIN_LOG_TIME
+            if min_log_time is None
+            else min_log_time
         )
         self._msg_displayed = False
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -95,8 +95,9 @@ def test_min_log_time_argument_sets_default():
     `timelog`."""
     from magpylib_material_response import logging_config  # noqa: PLC0415
 
-    configure_logging(level="DEBUG", enable_colors=False, sink=io.StringIO(),
-                      min_log_time=2.5)
+    configure_logging(
+        level="DEBUG", enable_colors=False, sink=io.StringIO(), min_log_time=2.5
+    )
     assert logging_config.DEFAULT_MIN_LOG_TIME == 2.5
 
 
@@ -114,8 +115,7 @@ def test_timelog_uses_default_min_log_time():
     from magpylib_material_response.utils import timelog  # noqa: PLC0415
 
     sink = io.StringIO()
-    configure_logging(level="DEBUG", enable_colors=False, sink=sink,
-                      min_log_time=0.0)
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink, min_log_time=0.0)
     with timelog("quick step"):
         pass
     assert "Completed: quick step" in sink.getvalue()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,121 @@
+"""Tests for the logging configuration module."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from loguru import logger
+
+from magpylib_material_response import configure_logging, disable_logging
+from magpylib_material_response.logging_config import PACKAGE
+
+
+def _emit_from_package(level: str, message: str, **kwargs) -> None:
+    """Emit a log record as if from inside the package (for filter testing)."""
+    logger.patch(lambda r: r.update(name=PACKAGE + ".test")).log(
+        level, message, **kwargs
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging():
+    """Ensure each test starts and ends with the package disabled."""
+    disable_logging()
+    yield
+    disable_logging()
+
+
+def test_silent_by_default():
+    """In the default state, the package is disabled in loguru so that no
+    record emitted from within the package will reach any sink."""
+    # disable_logging in the autouse fixture leaves the package disabled.
+    activation = dict(logger._core.activation_list)
+    assert activation.get("magpylib_material_response.") is False
+
+
+def test_configure_logging_enables_package():
+    configure_logging(level="DEBUG", enable_colors=False, sink=io.StringIO())
+    activation = dict(logger._core.activation_list)
+    assert activation.get("magpylib_material_response.") is True
+
+
+def test_configure_logging_emits_to_sink():
+    sink = io.StringIO()
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink)
+    _emit_from_package("INFO", "hello {x}", x=42)
+    assert "hello 42" in sink.getvalue()
+
+
+def test_configure_logging_does_not_remove_user_sinks():
+    user_sink = io.StringIO()
+    user_handler = logger.add(user_sink, level="DEBUG")
+    try:
+        configure_logging(level="DEBUG", enable_colors=False, sink=io.StringIO())
+        logger.info("user message")
+        assert "user message" in user_sink.getvalue()
+    finally:
+        logger.remove(user_handler)
+
+
+def test_disable_logging_silences_package_only():
+    user_sink = io.StringIO()
+    user_handler = logger.add(user_sink, level="DEBUG")
+    try:
+        disable_logging()
+        logger.info("still here")
+        assert "still here" in user_sink.getvalue()
+    finally:
+        logger.remove(user_handler)
+
+
+def test_reconfigure_replaces_only_own_sink():
+    sink1 = io.StringIO()
+    sink2 = io.StringIO()
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink1)
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink2)
+    _emit_from_package("INFO", "after reconfigure")
+    assert "after reconfigure" in sink2.getvalue()
+    assert sink1.getvalue() == ""
+
+
+def test_env_var_level(monkeypatch):
+    monkeypatch.setenv("MAGPYLIB_LOG_LEVEL", "WARNING")
+    sink = io.StringIO()
+    configure_logging(enable_colors=False, sink=sink)
+    _emit_from_package("INFO", "should not appear")
+    _emit_from_package("WARNING", "should appear")
+    out = sink.getvalue()
+    assert "should not appear" not in out
+    assert "should appear" in out
+
+
+def test_min_log_time_argument_sets_default():
+    """`min_log_time` argument must update the module-level default used by
+    `timelog`."""
+    from magpylib_material_response import logging_config  # noqa: PLC0415
+
+    configure_logging(
+        level="DEBUG", enable_colors=False, sink=io.StringIO(), min_log_time=2.5
+    )
+    assert logging_config.DEFAULT_MIN_LOG_TIME == 2.5
+
+
+def test_min_log_time_env_var(monkeypatch):
+    monkeypatch.setenv("MAGPYLIB_LOG_MIN_TIME", "0.25")
+    from magpylib_material_response import logging_config  # noqa: PLC0415
+
+    configure_logging(level="DEBUG", enable_colors=False, sink=io.StringIO())
+    assert logging_config.DEFAULT_MIN_LOG_TIME == 0.25
+
+
+def test_timelog_uses_default_min_log_time():
+    """When called with min_log_time=None, timelog must use the configured
+    default and emit a record only if the block exceeds it."""
+    from magpylib_material_response.utils import timelog  # noqa: PLC0415
+
+    sink = io.StringIO()
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink, min_log_time=0.0)
+    with timelog("quick step"):
+        pass
+    assert "Completed: quick step" in sink.getvalue()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,121 @@
+"""Tests for the logging configuration module."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from loguru import logger
+
+from magpylib_material_response import configure_logging, disable_logging
+from magpylib_material_response.logging_config import PACKAGE
+
+
+def _emit_from_package(level: str, message: str, **kwargs) -> None:
+    """Emit a log record as if from inside the package (for filter testing)."""
+    logger.patch(lambda r: r.update(name=PACKAGE + ".test")).log(
+        level, message, **kwargs
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging():
+    """Ensure each test starts and ends with the package disabled."""
+    disable_logging()
+    yield
+    disable_logging()
+
+
+def test_silent_by_default():
+    """In the default state, the package is disabled in loguru so that no
+    record emitted from within the package will reach any sink."""
+    # disable_logging in the autouse fixture leaves the package disabled.
+    activation = dict(logger._core.activation_list)
+    assert activation.get("magpylib_material_response.") is False
+
+
+def test_configure_logging_enables_package():
+    configure_logging(level="DEBUG", enable_colors=False, sink=io.StringIO())
+    activation = dict(logger._core.activation_list)
+    assert activation.get("magpylib_material_response.") is True
+
+
+def test_configure_logging_emits_to_sink():
+    sink = io.StringIO()
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink)
+    _emit_from_package("INFO", "hello {x}", x=42)
+    assert "hello 42" in sink.getvalue()
+
+
+def test_configure_logging_does_not_remove_user_sinks():
+    user_sink = io.StringIO()
+    user_handler = logger.add(user_sink, level="DEBUG")
+    try:
+        configure_logging(level="DEBUG", enable_colors=False, sink=io.StringIO())
+        logger.info("user message")
+        assert "user message" in user_sink.getvalue()
+    finally:
+        logger.remove(user_handler)
+
+
+def test_disable_logging_silences_package_only():
+    user_sink = io.StringIO()
+    user_handler = logger.add(user_sink, level="DEBUG")
+    try:
+        disable_logging()
+        logger.info("still here")
+        assert "still here" in user_sink.getvalue()
+    finally:
+        logger.remove(user_handler)
+
+
+def test_reconfigure_replaces_only_own_sink():
+    sink1 = io.StringIO()
+    sink2 = io.StringIO()
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink1)
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink2)
+    _emit_from_package("INFO", "after reconfigure")
+    assert "after reconfigure" in sink2.getvalue()
+    assert sink1.getvalue() == ""
+
+
+def test_env_var_level(monkeypatch):
+    monkeypatch.setenv("MAGPYLIB_LOG_LEVEL", "WARNING")
+    sink = io.StringIO()
+    configure_logging(enable_colors=False, sink=sink)
+    _emit_from_package("INFO", "should not appear")
+    _emit_from_package("WARNING", "should appear")
+    out = sink.getvalue()
+    assert "should not appear" not in out
+    assert "should appear" in out
+
+
+def test_min_log_time_argument_sets_default():
+    """`min_log_time` argument must update the module-level default used by
+    `timelog`."""
+    from magpylib_material_response import logging_config  # noqa: PLC0415
+
+    configure_logging(level="DEBUG", enable_colors=False, sink=io.StringIO(),
+                      min_log_time=2.5)
+    assert logging_config.DEFAULT_MIN_LOG_TIME == 2.5
+
+
+def test_min_log_time_env_var(monkeypatch):
+    monkeypatch.setenv("MAGPYLIB_LOG_MIN_TIME", "0.25")
+    from magpylib_material_response import logging_config  # noqa: PLC0415
+
+    configure_logging(level="DEBUG", enable_colors=False, sink=io.StringIO())
+    assert logging_config.DEFAULT_MIN_LOG_TIME == 0.25
+
+
+def test_timelog_uses_default_min_log_time():
+    """When called with min_log_time=None, timelog must use the configured
+    default and emit a record only if the block exceeds it."""
+    from magpylib_material_response.utils import timelog  # noqa: PLC0415
+
+    sink = io.StringIO()
+    configure_logging(level="DEBUG", enable_colors=False, sink=sink,
+                      min_log_time=0.0)
+    with timelog("quick step"):
+        pass
+    assert "Completed: quick step" in sink.getvalue()


### PR DESCRIPTION
# Improved Logging

Refactors logging to follow the
[loguru library recipe](https://loguru.readthedocs.io/en/stable/resources/recipes.html#configuring-loguru-to-be-used-by-a-library-or-an-application)
(addresses the spirit of magpylib/magpylib#953).

## Changes

- **Breaking:** silent by default. Call `configure_logging()` to opt in.
- Package no longer calls `logger.remove()` and never overrides user/application
  sinks. Silencing uses `logger.disable("magpylib_material_response")`.
- New `logging_config.py` with `configure_logging(level, enable_colors,
  show_time, sink, min_log_time)` and `disable_logging()`.
- Env-var overrides: `MAGPYLIB_LOG_LEVEL`, `MAGPYLIB_LOG_COLORS`,
  `MAGPYLIB_LOG_TIME`, `MAGPYLIB_LOG_MIN_TIME`.
- `min_log_time` centralized: configurable globally; `apply_demag` &
  friends honour it when their own arg is left at the new `None` default.
- Structured logging (`logger.info("msg {x}", x=...)`); removed embedded
  `<blue>` markup from message content; removed decorative emojis.
- Fix: `timelog` no longer crashes with `TypeError` on the exception path.
- New `docs/logging.md` and `tests/test_logging.py`.

## Usage

```python
from magpylib_material_response import configure_logging
from magpylib_material_response.demag import apply_demag

apply_demag(collection)              # silent
configure_logging()                  # enable INFO output to stderr
configure_logging(level="DEBUG", min_log_time=0)
```

If your app already configures loguru:

```python
from loguru import logger
logger.enable("magpylib_material_response")
```